### PR TITLE
docs: hide categories and subscriptions from required entities documentation

### DIFF
--- a/docs/connection-methods/database/README.md
+++ b/docs/connection-methods/database/README.md
@@ -27,7 +27,7 @@ El cliente debe crear tablas con la estructura especificada en la documentación
 
 - **Clientes**: Ver estructura en [Datos Maestros > Clientes](../../master-data/client/README.md)
 - **Productos**: Ver estructura en [Datos Maestros > Productos](../../master-data/product/README.md)
-- **Categorías**: Ver estructura en [Datos Maestros > Categorías](../../master-data/category/README.md)
+
 - **Vendedores**: Ver estructura en [Datos Maestros > Vendedores](../../master-data/seller/README.md)
 - **Transacciones**: Ver estructura en [Datos Maestros > Transacciones](../../master-data/transactions/README.md)
 

--- a/docs/connection-methods/database/README.md
+++ b/docs/connection-methods/database/README.md
@@ -27,7 +27,6 @@ El cliente debe crear tablas con la estructura especificada en la documentación
 
 - **Clientes**: Ver estructura en [Datos Maestros > Clientes](../../master-data/client/README.md)
 - **Productos**: Ver estructura en [Datos Maestros > Productos](../../master-data/product/README.md)
-
 - **Vendedores**: Ver estructura en [Datos Maestros > Vendedores](../../master-data/seller/README.md)
 - **Transacciones**: Ver estructura en [Datos Maestros > Transacciones](../../master-data/transactions/README.md)
 
@@ -36,7 +35,6 @@ El cliente debe crear tablas con la estructura especificada en la documentación
 ### Configuraciones
 - **Asignaciones**: Ver estructura en [Configuraciones > Asignaciones](../../settings/assignments/README.md)
 - **Rutas**: Ver estructura en [Configuraciones > Rutas](../../settings/routes/README.md)
-- **Suscripciones**: Ver estructura en [Configuraciones > Suscripciones](../../settings/subscription/README.md)
 
 > 💡 **Ver todas las configuraciones disponibles**: [Configuraciones](../../settings/README.md)
 

--- a/docs/connection-methods/file-based/README.md
+++ b/docs/connection-methods/file-based/README.md
@@ -30,7 +30,6 @@ Este método de integración funciona mediante:
 - `products_20241201_143025.csv`
 - `assignments_20241201_143030.csv`
 - `routes_20241201_143032.csv`
-- `subscriptions_20241201_143035.csv`
 
 > 💡 **Beneficios del timestamp**: Facilita la trazabilidad, ordenamiento cronológico y auditoría de archivos sincronizados.
 
@@ -49,8 +48,7 @@ reten-integration-{client_id}/
 ├── sellers/
 ├── transactions/
 ├── assignments/
-├── routes/
-└── subscriptions/
+└── routes/
 ```
 
 ## Estructura de Datos
@@ -60,7 +58,6 @@ Los archivos CSV deben contener las columnas especificadas en la documentación 
 ### Datos Maestros
 - **Clientes**: Ver estructura en [Datos Maestros > Clientes](../../master-data/client/README.md)
 - **Productos**: Ver estructura en [Datos Maestros > Productos](../../master-data/product/README.md)
-
 - **Vendedores**: Ver estructura en [Datos Maestros > Vendedores](../../master-data/seller/README.md)
 - **Transacciones**: Ver estructura en [Datos Maestros > Transacciones](../../master-data/transactions/README.md)
 
@@ -69,7 +66,6 @@ Los archivos CSV deben contener las columnas especificadas en la documentación 
 ### Configuraciones
 - **Asignaciones**: Ver estructura en [Configuraciones > Asignaciones](../../settings/assignments/README.md)
 - **Rutas**: Ver estructura en [Configuraciones > Rutas](../../settings/routes/README.md)
-- **Suscripciones**: Ver estructura en [Configuraciones > Suscripciones](../../settings/subscription/README.md)
 
 > 💡 **Ver todas las configuraciones disponibles**: [Configuraciones](../../settings/README.md)
 

--- a/docs/connection-methods/file-based/README.md
+++ b/docs/connection-methods/file-based/README.md
@@ -28,7 +28,6 @@ Este método de integración funciona mediante:
 **Ejemplos**:
 - `clients_20241201_143022.csv`
 - `products_20241201_143025.csv`
-- `categories_20241201_143028.csv`
 - `assignments_20241201_143030.csv`
 - `routes_20241201_143032.csv`
 - `subscriptions_20241201_143035.csv`
@@ -47,7 +46,6 @@ Reten proporciona un bucket compartido para cada cliente:
 reten-integration-{client_id}/
 ├── clients/
 ├── products/
-├── categories/
 ├── sellers/
 ├── transactions/
 ├── assignments/
@@ -62,7 +60,7 @@ Los archivos CSV deben contener las columnas especificadas en la documentación 
 ### Datos Maestros
 - **Clientes**: Ver estructura en [Datos Maestros > Clientes](../../master-data/client/README.md)
 - **Productos**: Ver estructura en [Datos Maestros > Productos](../../master-data/product/README.md)
-- **Categorías**: Ver estructura en [Datos Maestros > Categorías](../../master-data/category/README.md)
+
 - **Vendedores**: Ver estructura en [Datos Maestros > Vendedores](../../master-data/seller/README.md)
 - **Transacciones**: Ver estructura en [Datos Maestros > Transacciones](../../master-data/transactions/README.md)
 

--- a/docs/master-data/README.md
+++ b/docs/master-data/README.md
@@ -19,12 +19,7 @@ Los datos maestros representan la información fundamental y de referencia en el
     'product/README.md'
 ) }}
 
-{{ feature_card(
-    'material-shape',
-    'Categorías',
-    'Clasificación jerárquica de productos',
-    'category/README.md'
-) }}
+
 
 {{ feature_card(
     'material-account-tie',

--- a/docs/settings/README.md
+++ b/docs/settings/README.md
@@ -19,12 +19,6 @@ Las configuraciones representan las reglas y parámetros operativos que definen 
     'routes/README.md'
 ) }}
 
-{{ feature_card(
-    'material-bell',
-    'Suscripciones',
-    'Gestión de comunicaciones y notificaciones',
-    'subscription/README.md'
-) }}
 {% endcall %}
 
 ## Características Comunes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,6 @@ nav:
     - Resumen: master-data/README.md
     - Clientes: master-data/client/README.md
     - Productos: master-data/product/README.md
-    - Categorías: master-data/category/README.md
     - Vendedores: master-data/seller/README.md
     - Cupones: master-data/coupon/README.md
     - Transacciones: master-data/transactions/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,7 +98,6 @@ nav:
     - Resumen: settings/README.md
     - Asignaciones: settings/assignments/README.md
     - Rutas: settings/routes/README.md
-    - Suscripciones: settings/subscription/README.md
   - Tareas:
     - Resumen: tasks/README.md
     - Visitas: tasks/visit/README.md


### PR DESCRIPTION
## 📋 **Overview**

This PR hides the "Categories" and "Subscriptions" entities from the required entities documentation to simplify the integration requirements for clients.

## 🎯 **Key Changes**

### **Categories Entity Hidden:**
- Remove categories card from master-data main page
- Remove categories from file-based integration examples and structure
- Remove categories from database integration entity list
- Update mkdocs.yml navigation to exclude categories

### **Subscriptions Entity Hidden:**
- Remove subscriptions card from settings main page
- Remove subscriptions from file-based integration examples and structure
- Remove subscriptions from database integration entity list
- Update mkdocs.yml navigation to exclude subscriptions

## 🔧 **Technical Details**

### **Master Data:**
- **Categories**: No longer appears in the main master data list
- **File Integration**: Remove categories from CSV examples and bucket folder structure
- **Database Integration**: Remove categories from required entity documentation

### **Settings:**
- **Subscriptions**: No longer appears in the main configuration list
- **File Integration**: Remove subscriptions from CSV examples and bucket folder structure
- **Database Integration**: Remove subscriptions from required entity documentation

### **Navigation:**
- Update mkdocs.yml to exclude both categories and subscriptions from navigation menu
- Clean up empty lines and formatting

## 📁 **Files Modified**

### **Master Data:**
- `docs/master-data/README.md`: Remove categories feature card
- `docs/connection-methods/file-based/README.md`: Remove categories from examples and structure
- `docs/connection-methods/database/README.md`: Remove categories from entity list

### **Settings:**
- `docs/settings/README.md`: Remove subscriptions feature card
- `docs/connection-methods/file-based/README.md`: Remove subscriptions from examples and structure
- `docs/connection-methods/database/README.md`: Remove subscriptions from entity list

### **Configuration:**
- `mkdocs.yml`: Remove both entities from navigation menu

## 📊 **Impact**

- **Simplified Integration**: Clients no longer need to implement categories or subscriptions
- **Cleaner Documentation**: Focus on essential entities only
- **Reduced Complexity**: Fewer entities to implement and maintain
- **Maintained Access**: Both entity documentations still exist but not promoted as required

## 🧪 **Testing**

- [x] Documentation builds locally without errors
- [x] Navigation menu excludes hidden entities
- [x] Integration method documentation updated
- [x] All links and references properly removed

## 📝 **Notes**

- Both entity documentations remain accessible via direct links
- This change simplifies the onboarding process for new clients
- Focus is now on the core entities: Clients, Products, Sellers, Transactions, Assignments, and Routes
