### PR TITLE
docs: add comprehensive documentation for user-states endpoint

### DIFF
--- a/docs/data-consumption/README.md
+++ b/docs/data-consumption/README.md
@@ -24,16 +24,22 @@ Para consumir datos desde Reten, dispones de un método de conexión unificado:
 
 ## :material-format-list-bulleted-type: Tipos de Datos
 
-{% set tasks = [
+{% set data_types = [
     {
         'icon': 'material-checkbox-marked-circle',
         'title': 'Tareas',
         'link': './tasks/README.md',
         'description': 'Sistema de tareas, seguimiento y gestión de actividades.'
+    },
+    {
+        'icon': 'material-account-group',
+        'title': 'Estados de Usuario',
+        'link': './user-states/README.md',
+        'description': 'Clasificación y segmentación de usuarios según su engagement y comportamiento.'
     }
 ] %}
 
-{{ section_overview(tasks) }}
+{{ section_overview(data_types) }}
 
 ## :material-step-forward-2: Flujo de Implementación
 
@@ -44,15 +50,16 @@ Para implementar el consumo de datos en Reten, sigue estos pasos:
     - Configura tokens de acceso seguros
     - Establece permisos y scopes necesarios
 
-!!! note "2. Implementa el Consumo de Tareas"
-    - Configura endpoints para consultar tareas
-    - Implementa polling para sincronización periódica
-    - Establece filtros para obtener tareas específicas
+!!! note "2. Implementa el Consumo de Datos"
+    - Configura endpoints para consultar tareas y estados de usuario
+    - Implementa polling para sincronización periódica de ambos tipos de datos
+    - Establece filtros para obtener tareas específicas y segmentar usuarios por estado
 
 !!! note "3. Procesa y Utiliza los Datos"
-    - Integra las tareas en tu sistema de gestión
-    - Implementa flujos de trabajo para las actividades
-    - Configura notificaciones y alertas
+    - Integra las tareas en tu sistema de gestión y CRM
+    - Utiliza los estados de usuario para segmentación y personalización
+    - Implementa flujos de trabajo para las actividades basados en el estado del usuario
+    - Configura notificaciones y alertas según el engagement del usuario
 
 !!! note "4. Monitorea y Optimiza"
     - Revisa logs de consumo regularmente

--- a/docs/data-consumption/connection-methods/api-rest/README.md
+++ b/docs/data-consumption/connection-methods/api-rest/README.md
@@ -76,6 +76,59 @@ curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/tasks/
 !!! info "Documentación Interactiva"
     Para consultar la documentación completa del endpoint GET /api/v1/tasks, visita: [https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/docs#/tasks/get_task_api_v1_tasks__get](https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/docs#/tasks/get_task_api_v1_tasks__get)
 
+### **Consulta de Estados de Usuario**
+
+#### **Listar Estados de Usuario**
+```http
+GET /api/v1/kpis/users-states
+```
+
+**Parámetros de Query:**
+
+- `page`: Número de página (por defecto: 1)
+- `limit`: Número de elementos por página (por defecto: 100)
+- `kpi_value`: Filtrar por valor del KPI (opcional)
+- `date`: Filtrar por fecha (YYYY-MM-DD, opcional)
+- `user_id`: Filtrar por ID de usuario (opcional)
+
+**Ejemplo de Request:**
+```bash
+curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/kpis/users-states?page=1&limit=50&date=2024-01-15" \
+  -H "X-API-Key: your_api_key"
+```
+
+**Ejemplo de Respuesta:**
+```json
+{
+  "page": 1,
+  "limit": 50,
+  "total": 1000,
+  "next_page": 2,
+  "previous_page": null,
+  "data": [
+    {
+      "user_id": "user_123",
+      "kpi_name": "user_state",
+      "kpi_value": "core",
+      "date": "2024-01-15",
+      "segment_name": "engagement_level",
+      "segment_value": "high"
+    },
+    {
+      "user_id": "user_456",
+      "kpi_name": "user_state",
+      "kpi_value": "churned",
+      "date": "2024-01-15",
+      "segment_name": "engagement_level",
+      "segment_value": "low"
+    }
+  ]
+}
+```
+
+!!! info "Documentación Interactiva"
+    Para consultar la documentación completa del endpoint GET /api/v1/kpis/users-states, visita: [https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/docs#/kpis/get_kpis_users_states_api_v1_kpis_users_states_get](https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/docs#/kpis/get_kpis_users_states_api_v1_kpis_users_states_get)
+
 ## 🔧 Ejemplos de Uso
 
 ### **Python**
@@ -98,6 +151,20 @@ tasks_filtradas = response.json()
 params = {'channel_priority': 'salesman'}
 response = requests.get(f'{API_BASE_URL}/api/v1/tasks/', headers={'X-API-Key': API_KEY}, params=params)
 tasks_salesman = response.json()
+
+# Consultar estados de usuario
+response = requests.get(f'{API_BASE_URL}/api/v1/kpis/users-states', headers={'X-API-Key': API_KEY})
+user_states = response.json()
+
+# Consultar estados de usuario por fecha
+params = {'date': '2024-01-15', 'limit': 100}
+response = requests.get(f'{API_BASE_URL}/api/v1/kpis/users-states', headers={'X-API-Key': API_KEY}, params=params)
+user_states_filtrados = response.json()
+
+# Consultar estados de usuario específico
+params = {'user_id': 'user_123'}
+response = requests.get(f'{API_BASE_URL}/api/v1/kpis/users-states', headers={'X-API-Key': API_KEY}, params=params)
+user_states_especifico = response.json()
 ```
 
 ### **cURL**
@@ -112,6 +179,18 @@ curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/tasks/
 
 # Consultar tareas por canal de prioridad
 curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/tasks/?channel_priority=salesman" \
+  -H "X-API-Key: your_api_key"
+
+# Consultar estados de usuario
+curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/kpis/users-states" \
+  -H "X-API-Key: your_api_key"
+
+# Consultar estados de usuario por fecha
+curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/kpis/users-states?date=2024-01-15&limit=100" \
+  -H "X-API-Key: your_api_key"
+
+# Consultar estados de usuario específico
+curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/kpis/users-states?user_id=user_123" \
   -H "X-API-Key: your_api_key"
 ```
 

--- a/docs/data-consumption/user-states/README.md
+++ b/docs/data-consumption/user-states/README.md
@@ -1,0 +1,229 @@
+# :material-account-group: Estados de Usuario
+
+Los estados de usuario representan la clasificación de los usuarios según su comportamiento y engagement con la plataforma Reten. Esta entidad permite segmentar a los usuarios en diferentes categorías que reflejan su nivel de actividad, fidelidad y potencial de conversión.
+
+## Estructura de Datos
+
+```json
+{
+  // Identificadores
+  "user_id": "string",                 // Identificador único del usuario (not null)
+  "kpi_name": "string",                // Nombre del KPI, siempre "user_state" (not null)
+
+  // Información del estado
+  "kpi_value": "string",               // Estado del usuario (not null)
+                                       // Valores posibles: "aha", "casual", "churned", "core", "dormant", "habit", "power", "sign_up", "setup"
+
+  // Información temporal
+  "date": "string",                    // Fecha del estado en formato YYYY-MM-DD (not null)
+
+  // Información de segmentación (opcional)
+  "segment_name": "string",            // Nombre del segmento adicional
+  "segment_value": "string"            // Valor del segmento adicional
+}
+```
+
+## Campos Detallados
+
+### Identificadores
+
+| Campo    | Tipo   | Requerido | Descripción                           |
+| -------- | ------ | --------- | ------------------------------------- |
+| user_id  | string | Sí        | Identificador único del usuario       |
+| kpi_name | string | Sí        | Nombre del KPI (siempre "user_state") |
+
+### Información del Estado
+
+| Campo     | Tipo   | Requerido | Descripción                                        |
+| --------- | ------ | --------- | -------------------------------------------------- |
+| kpi_value | string | Sí        | Estado actual del usuario según el modelo de Reten |
+
+### Información Temporal
+
+| Campo | Tipo   | Requerido | Descripción                                      |
+| ----- | ------ | --------- | ------------------------------------------------ |
+| date  | string | Sí        | Fecha en que se determinó el estado (YYYY-MM-DD) |
+
+### Información de Segmentación
+
+| Campo         | Tipo   | Requerido | Descripción                   |
+| ------------- | ------ | --------- | ----------------------------- |
+| segment_name  | string | No        | Nombre del segmento adicional |
+| segment_value | string | No        | Valor del segmento adicional  |
+
+## Estados de Usuario Disponibles
+
+Los estados de usuario representan diferentes niveles de engagement y comportamiento:
+
+### **Estados Principales**
+
+| Estado      | Descripción                                                     |
+| ----------- | --------------------------------------------------------------- |
+| **sign_up** | Usuario recién registrado, sin actividad significativa          |
+| **aha**     | Usuario que ha tenido su primer momento "AHA" de descubrimiento |
+| **casual**  | Usuario con actividad esporádica y baja frecuencia              |
+| **habit**   | Usuario que ha desarrollado un hábito de uso regular            |
+| **core**    | Usuario altamente comprometido, núcleo del negocio              |
+| **power**   | Usuario power user con máxima actividad y engagement            |
+| **setup**   | Usuario en proceso de configuración inicial                     |
+
+### **Estados de Riesgo**
+
+| Estado      | Descripción                             |
+| ----------- | --------------------------------------- |
+| **dormant** | Usuario inactivo que podría reactivarse |
+| **churned** | Usuario que ha abandonado la plataforma |
+
+## Validaciones
+
+### Validaciones Generales
+
+#### Identificadores
+- `user_id` debe ser único y corresponder a un usuario existente en el sistema
+- `kpi_name` debe ser siempre "user_state"
+
+#### Estado del Usuario
+- `kpi_value` debe ser uno de los valores permitidos del enum de estados
+- Los estados siguen una jerarquía lógica de engagement creciente
+
+#### Fechas
+- `date` debe estar en formato YYYY-MM-DD
+- No puede ser una fecha futura
+
+#### Segmentación
+- Si se proporciona `segment_name`, debe existir `segment_value`
+- Los segmentos adicionales son opcionales y dependen de la configuración del negocio
+
+## Ejemplos de Uso
+
+### Usuario Core Activo
+
+```json
+{
+  "user_id": "user_123",
+  "kpi_name": "user_state",
+  "kpi_value": "core",
+  "date": "2024-01-15",
+  "segment_name": "engagement_level",
+  "segment_value": "high"
+}
+```
+
+### Usuario Nuevo en Setup
+
+```json
+{
+  "user_id": "user_456",
+  "kpi_name": "user_state",
+  "kpi_value": "setup",
+  "date": "2024-01-14"
+}
+```
+
+### Usuario Churned
+
+```json
+{
+  "user_id": "user_789",
+  "kpi_name": "user_state",
+  "kpi_value": "churned",
+  "date": "2024-01-10",
+  "segment_name": "churn_reason",
+  "segment_value": "inactivity"
+}
+```
+
+### Usuario Power User
+
+```json
+{
+  "user_id": "user_999",
+  "kpi_name": "user_state",
+  "kpi_value": "power",
+  "date": "2024-01-15",
+  "segment_name": "lifetime_value",
+  "segment_value": "premium"
+}
+```
+
+### Usuario Casual
+
+```json
+{
+  "user_id": "user_111",
+  "kpi_name": "user_state",
+  "kpi_value": "casual",
+  "date": "2024-01-13",
+  "segment_name": "frequency",
+  "segment_value": "weekly"
+}
+```
+
+### Usuario Dormant
+
+```json
+{
+  "user_id": "user_222",
+  "kpi_name": "user_state",
+  "kpi_value": "dormant",
+  "date": "2024-01-12",
+  "segment_name": "days_since_last_activity",
+  "segment_value": "60"
+}
+```
+
+## 🔄 Integración
+
+### **Método por API REST**
+
+!!! info "📖 Documentación Completa de Integración"
+    Para ejemplos detallados de implementación en Python, configuración de autenticación y estrategias avanzadas de consumo, consulta la documentación completa de la **[API REST](../../connection-methods/api-rest/README.md)**.
+
+#### Endpoint Principal
+```http
+GET /api/v1/kpis/users-states
+```
+
+#### Parámetros Disponibles
+- `page`: Número de página para paginación
+- `limit`: Número de elementos por página (máximo recomendado: 100)
+- `kpi_value`: Filtrar por estado específico del usuario
+- `date`: Filtrar por fecha específica (YYYY-MM-DD)
+- `user_id`: Filtrar por ID de usuario específico
+
+#### Ejemplo de Consulta
+```bash
+curl -X GET "https://retenai-analytics-api-lgtxgindmq-tl.a.run.app/api/v1/kpis/users-states?date=2024-01-15&kpi_value=core" \
+  -H "X-API-Key: your_api_key"
+```
+
+## Casos de Uso Comunes
+
+### **Segmentación de Usuarios**
+```python
+# Obtener todos los usuarios core para campañas de upselling
+params = {'kpi_value': 'core', 'limit': 1000}
+response = requests.get(f'{API_BASE_URL}/api/v1/kpis/users-states', headers=headers, params=params)
+core_users = response.json()
+```
+
+### **Monitoreo de Churn**
+```python
+# Identificar usuarios en riesgo de churn
+params = {'kpi_value': 'dormant', 'date': '2024-01-15'}
+response = requests.get(f'{API_BASE_URL}/api/v1/kpis/users-states', headers=headers, params=params)
+dormant_users = response.json()
+```
+
+### **Análisis de Engagement**
+```python
+# Analizar distribución de estados de usuario
+response = requests.get(f'{API_BASE_URL}/api/v1/kpis/users-states', headers=headers)
+all_states = response.json()
+
+# Contar usuarios por estado
+state_counts = {}
+for item in all_states['data']:
+    state = item['kpi_value']
+    state_counts[state] = state_counts.get(state, 0) + 1
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - Resumen: data-consumption/connection-methods/README.md
       - API REST: data-consumption/connection-methods/api-rest/README.md
     - Tareas: data-consumption/tasks/README.md
+    - Estados de Usuario: data-consumption/user-states/README.md
 
 # Additional settings
 plugins:


### PR DESCRIPTION
## Description
Complete documentation is added for the GET /api/v1/kpis/users-states endpoint of the Reten Analytics API, including:

• Endpoint documentation with parameters, request/response examples
• Creation of detailed documentation for the 'User States' entity
• Update of the root data-consumption README
• Python and cURL usage examples
• Validations and use cases for different user states

## Type of Change
- [x] New feature (documentation)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Other (specify)

## How has this been tested?
• Markdown syntax verification
• Documentation links validation
• Code examples review
• Tables and structure format verification

## Checklist
- [x] Tests added/updated (not applicable - documentation)
- [x] Documentation updated
- [x] Code conventions followed
- [x] Necessary dependencies updated (not applicable)

## Affected Files
• `docs/data-consumption/README.md` (modified)
• `docs/data-consumption/connection-methods/api-rest/README.md` (modified)
• `docs/data-consumption/user-states/README.md` (new)

## Related Issues
• Reten Analytics REST API documentation
• Data consumption documentation improvement